### PR TITLE
feature/5373/certs-manually-manage

### DIFF
--- a/coreos/docker/front/docker-compose.yml
+++ b/coreos/docker/front/docker-compose.yml
@@ -4,19 +4,24 @@ services:
   nginx:
     build: ./nginx-proxy/
     volumes:
-      - /mnt/data/docker/front/nginx-proxy/certs:/etc/nginx/certs:ro
       - /mnt/data/docker/front/nginx-proxy/vhost.d:/etc/nginx/vhost.d
       - /usr/share/nginx/html
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/redmine.u6k.me/fullchain1.pem:/etc/nginx/certs/redmine.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/redmine.u6k.me/privkey1.pem:/etc/nginx/certs/redmine.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/fullchain1.pem:/etc/nginx/certs/gitlab.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/privkey1.pem:/etc/nginx/certs/gitlab.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/jenkins.u6k.me/fullchain1.pem:/etc/nginx/certs/jenkins.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/jenkins.u6k.me/privkey1.pem:/etc/nginx/certs/jenkins.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/owncloud.u6k.me/fullchain1.pem:/etc/nginx/certs/owncloud.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/owncloud.u6k.me/privkey1.pem:/etc/nginx/certs/owncloud.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/registry.u6k.me/fullchain1.pem:/etc/nginx/certs/registry.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/registry.u6k.me/privkey1.pem:/etc/nginx/certs/registry.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/registry-web.u6k.me/fullchain1.pem:/etc/nginx/certs/registry-web.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/registry-web.u6k.me/privkey1.pem:/etc/nginx/certs/registry-web.u6k.me.key:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/zabbix.u6k.me/fullchain1.pem:/etc/nginx/certs/zabbix.u6k.me.crt:ro
+      - /mnt/data/docker/letsencrypt/certs/archive/zabbix.u6k.me/privkey1.pem:/etc/nginx/certs/zabbix.u6k.me.key:ro
     ports:
       - "80:80"
       - "443:443"
-    restart: always
-  cert:
-    image: jrcs/letsencrypt-nginx-proxy-companion
-    volumes:
-      - /mnt/data/docker/front/nginx-proxy/certs:/etc/nginx/certs:rw
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    volumes_from:
-      - nginx
     restart: always

--- a/coreos/docker/gitlab/docker-compose.yml
+++ b/coreos/docker/gitlab/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     environment:
       - VIRTUAL_HOST=gitlab.u6k.me
       - VIRTUAL_PORT=80
-      - LETSENCRYPT_HOST=gitlab.u6k.me
-      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
       - GITLAB_OMNIBUS_CONFIG="external_url 'https://gitlab.u6k.me';"
 #    ports:
 #      - "22:22"

--- a/coreos/docker/jenkins/docker-compose.yml
+++ b/coreos/docker/jenkins/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     environment:
       - VIRTUAL_HOST=jenkins.u6k.me
       - VIRTUAL_PORT=8080
-      - LETSENCRYPT_HOST=jenkins.u6k.me
-      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     restart: always
 
 networks:

--- a/coreos/docker/owncloud/docker-compose.yml
+++ b/coreos/docker/owncloud/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     environment:
       - VIRTUAL_HOST=owncloud.u6k.me
       - VIRTUAL_PORT=80
-      - LETSENCRYPT_HOST=owncloud.u6k.me
-      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     volumes:
       - /mnt/data/docker/owncloud/owncloud:/var/www/html
     links:

--- a/coreos/docker/redmine/docker-compose.yml
+++ b/coreos/docker/redmine/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     environment:
       - VIRTUAL_HOST=redmine.u6k.me
       - VIRTUAL_PORT=3000
-      - LETSENCRYPT_HOST=redmine.u6k.me
-      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
       - MYSQL_PORT_3306_TCP=tcp://mysql:3306
       - MYSQL_ENV_MYSQL_USER=redmine_user
       - MYSQL_ENV_MYSQL_PASSWORD=redmine_pass

--- a/coreos/docker/zabbix/docker-compose.yml
+++ b/coreos/docker/zabbix/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - ZS_DBPassword=zabbix_pass
       - VIRTUAL_HOST=zabbix.u6k.me
       - VIRTUAL_PORT=80
-      - LETSENCRYPT_HOST=zabbix.u6k.me
-      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     volumes:
       - /etc/localtime:/etc/localtime:ro
     links:


### PR DESCRIPTION
letsencrypt-nginx-proxy-companionによるサーバー証明書自動生成をやめて、手動生成したサーバー証明書をnginx-proxyに明示指定するように変更しました。LETSENCRYPT_HOST指定してもサーバー証明書が生成されないことがあったためです。また、各サービスの`docker-compose.yml`からLETSENCRYPT系環境変数を削除しました。