### PR TITLE
feature/5405_letsencrypt-nginx-proxy

### DIFF
--- a/coreos/docker/front/docker-compose.yml
+++ b/coreos/docker/front/docker-compose.yml
@@ -3,28 +3,22 @@ version: '2'
 services:
   nginx:
     build: ./nginx-proxy/
+    privileged: true
     volumes:
-      - /mnt/data/docker/front/nginx-proxy/vhost.d:/etc/nginx/vhost.d
+      - /mnt/data/docker/front/nginx-proxy/certs:/etc/nginx/certs:ro
+      - /etc/nginx/vhost.d
       - /usr/share/nginx/html
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - /mnt/data/docker/front/nginx-proxy/htpasswd:/etc/nginx/htpasswd
-      - /mnt/data/docker/letsencrypt/certs/archive/redmine.u6k.me/fullchain1.pem:/etc/nginx/certs/redmine.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/redmine.u6k.me/privkey1.pem:/etc/nginx/certs/redmine.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/fullchain1.pem:/etc/nginx/certs/gitlab.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/privkey1.pem:/etc/nginx/certs/gitlab.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/jenkins.u6k.me/fullchain1.pem:/etc/nginx/certs/jenkins.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/jenkins.u6k.me/privkey1.pem:/etc/nginx/certs/jenkins.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/owncloud.u6k.me/fullchain1.pem:/etc/nginx/certs/owncloud.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/owncloud.u6k.me/privkey1.pem:/etc/nginx/certs/owncloud.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/registry.u6k.me/fullchain1.pem:/etc/nginx/certs/registry.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/registry.u6k.me/privkey1.pem:/etc/nginx/certs/registry.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/registry-web.u6k.me/fullchain1.pem:/etc/nginx/certs/registry-web.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/registry-web.u6k.me/privkey1.pem:/etc/nginx/certs/registry-web.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/zabbix.u6k.me/fullchain1.pem:/etc/nginx/certs/zabbix.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/zabbix.u6k.me/privkey1.pem:/etc/nginx/certs/zabbix.u6k.me.key:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/rutorrent.u6k.me/fullchain1.pem:/etc/nginx/certs/rutorrent.u6k.me.crt:ro
-      - /mnt/data/docker/letsencrypt/certs/archive/rutorrent.u6k.me/privkey1.pem:/etc/nginx/certs/rutorrent.u6k.me.key:ro
     ports:
       - "80:80"
       - "443:443"
+    restart: always
+  cert:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    privileged: true
+    volumes:
+      - /mnt/data/docker/front/nginx-proxy/certs:/etc/nginx/certs:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    volumes_from:
+      - nginx
     restart: always

--- a/coreos/docker/gitlab/docker-compose.yml
+++ b/coreos/docker/gitlab/docker-compose.yml
@@ -8,10 +8,14 @@ services:
       - /mnt/data/docker/gitlab/config:/etc/gitlab
       - /mnt/data/docker/gitlab/logs:/var/log/gitlab
       - /mnt/data/docker/gitlab/data:/var/opt/gitlab
+      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/fullchain1.pem:/etc/gitlab/ssl/gitlab.u6k.me.crt
+      - /mnt/data/docker/letsencrypt/certs/archive/gitlab.u6k.me/privkey1.pem:/etc/gitlab/ssl/gitlab.u6k.me.key
     environment:
       - VIRTUAL_HOST=gitlab.u6k.me
-      - VIRTUAL_PORT=80
-      - GITLAB_OMNIBUS_CONFIG="external_url 'https://gitlab.u6k.me'; registry_external_url 'https://registry.u6k.me';"
+      - VIRTUAL_PORT=443
+      - VIRTUAL_PROTO=https
+      - LETSENCRYPT_HOST=gitlab.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
 #    ports:
 #      - "22:22"
     restart: always
@@ -29,6 +33,8 @@ services:
       - VIRTUAL_HOST=registry.u6k.me
       - VIRTUAL_PORT=5000
       - VIRTUAL_PROTO=https
+      - LETSENCRYPT_HOST=registry.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     volumes:
       - /mnt/data/docker/registry/data:/var/lib/registry
       - /mnt/data/docker/letsencrypt/certs/archive/registry.u6k.me/fullchain1.pem:/certs/registry.u6k.me.crt:ro
@@ -42,6 +48,8 @@ services:
       - ENV_DOCKER_REGISTRY_USE_SSL=1
       - VIRTUAL_HOST=registry-web.u6k.me
       - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=registry-web.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     restart: always
 
 networks:

--- a/coreos/docker/jenkins/docker-compose.yml
+++ b/coreos/docker/jenkins/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       - VIRTUAL_HOST=jenkins.u6k.me
       - VIRTUAL_PORT=8080
+      - LETSENCRYPT_HOST=jenkins.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     restart: always
 
 networks:

--- a/coreos/docker/owncloud/docker-compose.yml
+++ b/coreos/docker/owncloud/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     environment:
       - VIRTUAL_HOST=owncloud.u6k.me
       - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=owncloud.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     volumes:
       - /mnt/data/docker/owncloud/owncloud:/var/www/html
     links:

--- a/coreos/docker/redmine/docker-compose.yml
+++ b/coreos/docker/redmine/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       - VIRTUAL_HOST=redmine.u6k.me
       - VIRTUAL_PORT=3000
+      - LETSENCRYPT_HOST=redmine.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
       - MYSQL_PORT_3306_TCP=tcp://mysql:3306
       - MYSQL_ENV_MYSQL_USER=redmine_user
       - MYSQL_ENV_MYSQL_PASSWORD=redmine_pass

--- a/coreos/docker/zabbix/docker-compose.yml
+++ b/coreos/docker/zabbix/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - ZS_DBPassword=zabbix_pass
       - VIRTUAL_HOST=zabbix.u6k.me
       - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=zabbix.u6k.me
+      - LETSENCRYPT_EMAIL=u6k.apps@gmail.com
     volumes:
       - /etc/localtime:/etc/localtime:ro
     links:


### PR DESCRIPTION
サーバー証明書を個別管理するのではなく、`jrcs/docker-letsencrypt-nginx-proxy-companion`を使用して自動管理されるように変更しました。